### PR TITLE
Add Atom feeds to the download page

### DIFF
--- a/Juggluco/download.html
+++ b/Juggluco/download.html
@@ -3,6 +3,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <link rel="icon" href="arrow.png">
+    <link rel="alternate" href="https://github.com/j-kaltes/j-kaltes.github.io/commits/primary/Juggluco/download.html.atom" title="Juggluco Download Page Updates (via Github)" type="application/atom+xml">	    
     <title>Download Juggluco</title>
     <style type="text/css">
   @page { size: 8.27in 11.69in; margin: 0.79in }
@@ -128,7 +129,9 @@ you can install an old version of Juggluco without these problems.</span></span>
     <p>Send an e-mail to <a href="mailto:jaapkorthalsaltes@gmail.com?subject=Send%20update%20reminders%20for%20Juggluco">jaapkorthalsaltes@gmail.com</a> to be reminded of future updates. You can also receive updates of the arm64 version by installing
 Juggluco via the <a href="https://uptodown-android.en.uptodown.com/android">Uptodown
 app</a> and maybe <a href="https://appgallery.huawei.com/#/app/C27162">App
-Gallery</a> or <a href="https://global.app.mi.com/details?id=tk.glucodata">GetApps</a>. It is also possible to press on <i>watch</i> in one of the repositories of <a href="https://github.com/j-kaltes">https://github.com/j-kaltes</a>. For example <a href="https://github.com/j-kaltes/Juggluco">https://github.com/j-kaltes/Juggluco</a> to be notified of activity in the source of Juggluco or <a href="https://github.com/j-kaltes/j-kaltes.github.io">https://github.com/j-kaltes/j-kaltes.github.io</a> to be notified of modifications in www.juggluco.nl (including the download page).</p>
+Gallery</a> or <a href="https://global.app.mi.com/details?id=tk.glucodata">GetApps</a>.</p>
+    <p>You can also monitor this download page for future changes (mostly updates about new releases) by following it as an <a href="https://github.com/j-kaltes/j-kaltes.github.io/commits/primary/Juggluco/download.html.atom" type="application/atom+xml">Atom feed (“RSS”)</a> using your feed reader app of choice.</p>
+    <p>It is also possible to press on <i>watch</i> in one of the repositories of <a href="https://github.com/j-kaltes">https://github.com/j-kaltes</a>. For example <a href="https://github.com/j-kaltes/Juggluco">https://github.com/j-kaltes/Juggluco</a> to be notified of activity in the source of Juggluco or <a href="https://github.com/j-kaltes/j-kaltes.github.io">https://github.com/j-kaltes/j-kaltes.github.io</a> to be notified of modifications in www.juggluco.nl (including the download page).</p>
 <h2 class="western">Testers</h2>
     <p>Juggluco can be used with Freestyle Libre 1, US 14 Days FreeStyle Libre
       1, FreeStyle Libre 2, US/CA/AU FreeStyle Libre 2 and FreeStyle Libre 3


### PR DESCRIPTION
Add instructions for following commits to “download.html” as an Atom feed.

Add feed auto-discovery meta tag.

Github generates a feed per file of commits to said file. Super useful way of following releases without getting notified about every commit in the entire project.